### PR TITLE
Event card styling and other slight fixes to website for better responsiveness - retry

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,7 +1,62 @@
 declare module 'astro:content' {
+	interface Render {
+		'.mdx': Promise<{
+			Content: import('astro').MarkdownInstance<{}>['Content'];
+			headings: import('astro').MarkdownHeading[];
+			remarkPluginFrontmatter: Record<string, any>;
+		}>;
+	}
+}
+declare module 'astro:content' {
+	interface Render {
+		'.md': Promise<{
+			Content: import('astro').MarkdownInstance<{}>['Content'];
+			headings: import('astro').MarkdownHeading[];
+			remarkPluginFrontmatter: Record<string, any>;
+		}>;
+	}
+}
+
+declare module 'astro:content' {
 	export { z } from 'astro/zod';
-	export type CollectionEntry<C extends keyof typeof entryMap> =
-		(typeof entryMap)[C][keyof (typeof entryMap)[C]] & Render;
+	export type CollectionEntry<C extends keyof AnyEntryMap> = AnyEntryMap[C][keyof AnyEntryMap[C]];
+
+	// TODO: Remove this when having this fallback is no longer relevant. 2.3? 3.0? - erika, 2023-04-04
+	/**
+	 * @deprecated
+	 * `astro:content` no longer provide `image()`.
+	 *
+	 * Please use it through `schema`, like such:
+	 * ```ts
+	 * import { defineCollection, z } from "astro:content";
+	 *
+	 * defineCollection({
+	 *   schema: ({ image }) =>
+	 *     z.object({
+	 *       image: image(),
+	 *     }),
+	 * });
+	 * ```
+	 */
+	export const image: never;
+
+	// This needs to be in sync with ImageMetadata
+	export type ImageFunction = () => import('astro/zod').ZodObject<{
+		src: import('astro/zod').ZodString;
+		width: import('astro/zod').ZodNumber;
+		height: import('astro/zod').ZodNumber;
+		format: import('astro/zod').ZodUnion<
+			[
+				import('astro/zod').ZodLiteral<'png'>,
+				import('astro/zod').ZodLiteral<'jpg'>,
+				import('astro/zod').ZodLiteral<'jpeg'>,
+				import('astro/zod').ZodLiteral<'tiff'>,
+				import('astro/zod').ZodLiteral<'webp'>,
+				import('astro/zod').ZodLiteral<'gif'>,
+				import('astro/zod').ZodLiteral<'svg'>
+			]
+		>;
+	}>;
 
 	type BaseSchemaWithoutEffects =
 		| import('astro/zod').AnyZodObject
@@ -16,63 +71,149 @@ declare module 'astro:content' {
 		| BaseSchemaWithoutEffects
 		| import('astro/zod').ZodEffects<BaseSchemaWithoutEffects>;
 
-	type BaseCollectionConfig<S extends BaseSchema> = {
-		schema?: S;
-		slug?: (entry: {
-			id: CollectionEntry<keyof typeof entryMap>['id'];
-			defaultSlug: string;
-			collection: string;
-			body: string;
-			data: import('astro/zod').infer<S>;
-		}) => string | Promise<string>;
-	};
-	export function defineCollection<S extends BaseSchema>(
-		input: BaseCollectionConfig<S>
-	): BaseCollectionConfig<S>;
+	export type SchemaContext = { image: ImageFunction };
 
-	type EntryMapKeys = keyof typeof entryMap;
+	type DataCollectionConfig<S extends BaseSchema> = {
+		type: 'data';
+		schema?: S | ((context: SchemaContext) => S);
+	};
+
+	type ContentCollectionConfig<S extends BaseSchema> = {
+		type?: 'content';
+		schema?: S | ((context: SchemaContext) => S);
+	};
+
+	type CollectionConfig<S> = ContentCollectionConfig<S> | DataCollectionConfig<S>;
+
+	export function defineCollection<S extends BaseSchema>(
+		input: CollectionConfig<S>
+	): CollectionConfig<S>;
+
 	type AllValuesOf<T> = T extends any ? T[keyof T] : never;
-	type ValidEntrySlug<C extends EntryMapKeys> = AllValuesOf<(typeof entryMap)[C]>['slug'];
+	type ValidContentEntrySlug<C extends keyof ContentEntryMap> = AllValuesOf<
+		ContentEntryMap[C]
+	>['slug'];
 
 	export function getEntryBySlug<
-		C extends keyof typeof entryMap,
-		E extends ValidEntrySlug<C> | (string & {})
+		C extends keyof ContentEntryMap,
+		E extends ValidContentEntrySlug<C> | (string & {})
 	>(
 		collection: C,
 		// Note that this has to accept a regular string too, for SSR
 		entrySlug: E
-	): E extends ValidEntrySlug<C>
+	): E extends ValidContentEntrySlug<C>
 		? Promise<CollectionEntry<C>>
 		: Promise<CollectionEntry<C> | undefined>;
-	export function getCollection<C extends keyof typeof entryMap>(
+
+	export function getDataEntryById<C extends keyof DataEntryMap, E extends keyof DataEntryMap[C]>(
 		collection: C,
-		filter?: (data: CollectionEntry<C>) => boolean
+		entryId: E
+	): Promise<CollectionEntry<C>>;
+
+	export function getCollection<C extends keyof AnyEntryMap, E extends CollectionEntry<C>>(
+		collection: C,
+		filter?: (entry: CollectionEntry<C>) => entry is E
+	): Promise<E[]>;
+	export function getCollection<C extends keyof AnyEntryMap>(
+		collection: C,
+		filter?: (entry: CollectionEntry<C>) => unknown
 	): Promise<CollectionEntry<C>[]>;
 
-	type InferEntrySchema<C extends keyof typeof entryMap> = import('astro/zod').infer<
-		Required<ContentConfig['collections'][C]>['schema']
+	export function getEntry<
+		C extends keyof ContentEntryMap,
+		E extends ValidContentEntrySlug<C> | (string & {})
+	>(entry: {
+		collection: C;
+		slug: E;
+	}): E extends ValidContentEntrySlug<C>
+		? Promise<CollectionEntry<C>>
+		: Promise<CollectionEntry<C> | undefined>;
+	export function getEntry<
+		C extends keyof DataEntryMap,
+		E extends keyof DataEntryMap[C] | (string & {})
+	>(entry: {
+		collection: C;
+		id: E;
+	}): E extends keyof DataEntryMap[C]
+		? Promise<DataEntryMap[C][E]>
+		: Promise<CollectionEntry<C> | undefined>;
+	export function getEntry<
+		C extends keyof ContentEntryMap,
+		E extends ValidContentEntrySlug<C> | (string & {})
+	>(
+		collection: C,
+		slug: E
+	): E extends ValidContentEntrySlug<C>
+		? Promise<CollectionEntry<C>>
+		: Promise<CollectionEntry<C> | undefined>;
+	export function getEntry<
+		C extends keyof DataEntryMap,
+		E extends keyof DataEntryMap[C] | (string & {})
+	>(
+		collection: C,
+		id: E
+	): E extends keyof DataEntryMap[C]
+		? Promise<DataEntryMap[C][E]>
+		: Promise<CollectionEntry<C> | undefined>;
+
+	/** Resolve an array of entry references from the same collection */
+	export function getEntries<C extends keyof ContentEntryMap>(
+		entries: {
+			collection: C;
+			slug: ValidContentEntrySlug<C>;
+		}[]
+	): Promise<CollectionEntry<C>[]>;
+	export function getEntries<C extends keyof DataEntryMap>(
+		entries: {
+			collection: C;
+			id: keyof DataEntryMap[C];
+		}[]
+	): Promise<CollectionEntry<C>[]>;
+
+	export function reference<C extends keyof AnyEntryMap>(
+		collection: C
+	): import('astro/zod').ZodEffects<
+		import('astro/zod').ZodString,
+		C extends keyof ContentEntryMap
+			? {
+					collection: C;
+					slug: ValidContentEntrySlug<C>;
+			  }
+			: {
+					collection: C;
+					id: keyof DataEntryMap[C];
+			  }
+	>;
+	// Allow generic `string` to avoid excessive type errors in the config
+	// if `dev` is not running to update as you edit.
+	// Invalid collection names will be caught at build time.
+	export function reference<C extends string>(
+		collection: C
+	): import('astro/zod').ZodEffects<import('astro/zod').ZodString, never>;
+
+	type ReturnTypeOrOriginal<T> = T extends (...args: any[]) => infer R ? R : T;
+	type InferEntrySchema<C extends keyof AnyEntryMap> = import('astro/zod').infer<
+		ReturnTypeOrOriginal<Required<ContentConfig['collections'][C]>['schema']>
 	>;
 
-	type Render = {
-		render(): Promise<{
-			Content: import('astro').MarkdownInstance<{}>['Content'];
-			headings: import('astro').MarkdownHeading[];
-			remarkPluginFrontmatter: Record<string, any>;
-		}>;
-	};
-
-	const entryMap: {
+	type ContentEntryMap = {
 		"blog": {
 "junteenth-recognition-concert.mdx": {
-  id: "junteenth-recognition-concert.mdx",
-  slug: "junteenth-recognition-concert",
-  body: string,
-  collection: "blog",
+	id: "junteenth-recognition-concert.mdx";
+  slug: "junteenth-recognition-concert";
+  body: string;
+  collection: "blog";
   data: InferEntrySchema<"blog">
-},
-},
+} & { render(): Render[".mdx"] };
+};
 
 	};
+
+	type DataEntryMap = {
+		
+	};
+
+	type AnyEntryMap = ContentEntryMap & DataEntryMap;
 
 	type ContentConfig = typeof import("../src/content/config");
 }

--- a/src/assets/scss/base/_list.scss
+++ b/src/assets/scss/base/_list.scss
@@ -6,8 +6,6 @@
 
 ul:not([class]),
 ol:not([class]) {
-  margin-left: 1rem;
-
   ul,
   ol {
     padding: 0.5rem 1rem 0;

--- a/src/components/Banner.astro
+++ b/src/components/Banner.astro
@@ -6,8 +6,8 @@ import Icon from 'astro-icon'
   class="flex justify-center bg-neutral-900 px-6 py-2 text-neutral-100 dark:bg-neutral-200 dark:text-neutral-900 sm:justify-between"
 >
   <p class="hidden text-center sm:block">Entertain, Educate, and Elevate Through Music.</p>
-  <div class="flex">
-    <p>Connect with Us</p>
+  <div class="flex items-center">
+    <p class="text-[14px] sm:text-sm">Connect with Us</p>
     <div class="flex space-x-4 pl-4">
       <Icon name="mdi:facebook-box" class="w-6 h-6" />
       <Icon name="mdi:instagram" class="w-6 h-6" />

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -5,10 +5,10 @@ import { DarkMode } from 'accessible-astro-components'
 ---
 
 <div id="main-navigation" class="is-desktop py-8">
-  <div class="container">
-    <a href="/" class="flex items-center gap-2 !no-underline" id="logo-title">
+  <div class="container flex items-center">
+    <a href="/" class="flex flex-row items-center gap-2 !no-underline" id="logo-title">
       <img src={(await import('../assets/img/logo.svg')).default} alt="SAMF Logo" width="47" height="37" />
-      <span class="font-bold uppercase">St. Augustine Music Festival</span>
+      <span class="font-bold uppercase pb-1">St. Augustine Music Festival</span>
     </a>
     <div class="wrapper mb-1 flex justify-between">
       <nav class="desktop-menu" aria-label="Main navigation desktop">
@@ -222,6 +222,9 @@ import { DarkMode } from 'accessible-astro-components'
         justify-content: space-between;
       }
       @media (min-width: 417px) and (max-width: 732px) {
+        justify-content: space-between;
+      }
+      @media (min-width: 859px) and (max-width: 1023px) {
         justify-content: space-between;
       }
     }

--- a/src/content/blog/junteenth-recognition-concert.mdx
+++ b/src/content/blog/junteenth-recognition-concert.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Juneteenth Recognition Concert'
 description: 'The Ritz Chamber Players will perform a concert in recognition of Juneteenth. The concert will feature music by African American composers. Our special guest for the night will be Ann Marie McPhail, soprano.'
-pubDate: 'Jul 02 2022'
+pubDate: ''
 heroImage: ''
 ---
 import { Icon } from 'astro-icon'

--- a/src/layouts/DefaultLayout.astro
+++ b/src/layouts/DefaultLayout.astro
@@ -98,6 +98,13 @@ const {
           }
         }
       }
+
+      #main-content {
+        @media (min-width: 582px) and (max-width: 639px) {
+        display: flex;
+        justify-content: center;
+      }
+      }
     </style>
   </body>
 </html>

--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -1,4 +1,5 @@
 ---
+import { Card } from 'accessible-astro-components'
 import DefaultLayout from '../../layouts/DefaultLayout.astro'
 import { getCollection } from 'astro:content'
 
@@ -10,11 +11,34 @@ const posts = (await getCollection('blog')).sort((a, b) => a.data.pubDate.valueO
     <ul>
       {
         posts.map((post) => (
-          <li>
-            <a href={`/events/${post.slug}/`}>{post.data.title}</a>
-          </li>
+          <div class="relative mb-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+            <Card
+              url={`/events/${post.slug}/`}
+              img="/event-assets/juneteenth-placehold.png/"
+              title=""
+              children=""
+              footer=""
+            >
+              <h3 class="mb-2">{post.data.title}</h3>
+              <div class="flex flex-col">
+                <div class="mt-3 flex flex-col gap-[6px]">
+                  <p class="font-semibold">The Ritz Chamber Players</p>
+                  <p class="text-xs italic">with special guest</p>
+                  <p class="font-semibold">
+                    Anne Marie McPhail, <i>Soprano</i>
+                  </p>
+                </div>
+                <div class="absolute flex flex-col items-center bottom-0 cal:bottom-[2rem] right-0 border-l-2 border-t-2 sm:border-2 border-neutral-900 px-2 sm:m-4 cal:m-1 lg:m-2 cal:px-[0.75rem] sm:px-[0.65rem] sm:py-1 lg:px-3">
+                  <p>June</p>
+                  <p class="text-3xl font-bold">19</p>
+                </div>
+              </div>
+            </Card>
+          </div>
         ))
       }
     </ul>
   </section>
 </DefaultLayout>
+
+<!-- 640  729-->

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,8 @@ module.exports = {
       screens: {
         'custom': { 'raw': '(min-width: 1024px) and (max-width: 1083px)' },
         'post-custom': { 'raw': '(min-width: 1084px)' },
+        'cal': { 'raw': '(min-width: 640px) and (max-width: 728px)' },
+        'p-cal': { 'raw': '(min-width: 729px)' },
       },
       colors: {
         primary: {


### PR DESCRIPTION
# What got done
### Events
- Card is looking great and it fully responsive. Card array is gridded up and ready to populate with more events.
- added new tailwind screens for minor edge cases with the styling

### Minor Tweaks
- Tweaked some of the SCSS and Tailwind by adding custom media queries for better responsiveness
     - `ul` tag lost it's margin left as it was looking bad with the card on small screens.
     - `DefaultLayout.astro` got a custom media query at an edge case screen-width range.
     - `Navigation.astro` got fixed as a result to the `ul` tweak as it was running into the same problem where it was running to close to the banner logo.
     - `Banner.astro` is now perfectly centered as it was just a *little* bit off before.
 
