### PR TITLE
Dynamic events

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,7 +1,62 @@
 declare module 'astro:content' {
+	interface Render {
+		'.mdx': Promise<{
+			Content: import('astro').MarkdownInstance<{}>['Content'];
+			headings: import('astro').MarkdownHeading[];
+			remarkPluginFrontmatter: Record<string, any>;
+		}>;
+	}
+}
+declare module 'astro:content' {
+	interface Render {
+		'.md': Promise<{
+			Content: import('astro').MarkdownInstance<{}>['Content'];
+			headings: import('astro').MarkdownHeading[];
+			remarkPluginFrontmatter: Record<string, any>;
+		}>;
+	}
+}
+
+declare module 'astro:content' {
 	export { z } from 'astro/zod';
-	export type CollectionEntry<C extends keyof typeof entryMap> =
-		(typeof entryMap)[C][keyof (typeof entryMap)[C]] & Render;
+	export type CollectionEntry<C extends keyof AnyEntryMap> = AnyEntryMap[C][keyof AnyEntryMap[C]];
+
+	// TODO: Remove this when having this fallback is no longer relevant. 2.3? 3.0? - erika, 2023-04-04
+	/**
+	 * @deprecated
+	 * `astro:content` no longer provide `image()`.
+	 *
+	 * Please use it through `schema`, like such:
+	 * ```ts
+	 * import { defineCollection, z } from "astro:content";
+	 *
+	 * defineCollection({
+	 *   schema: ({ image }) =>
+	 *     z.object({
+	 *       image: image(),
+	 *     }),
+	 * });
+	 * ```
+	 */
+	export const image: never;
+
+	// This needs to be in sync with ImageMetadata
+	export type ImageFunction = () => import('astro/zod').ZodObject<{
+		src: import('astro/zod').ZodString;
+		width: import('astro/zod').ZodNumber;
+		height: import('astro/zod').ZodNumber;
+		format: import('astro/zod').ZodUnion<
+			[
+				import('astro/zod').ZodLiteral<'png'>,
+				import('astro/zod').ZodLiteral<'jpg'>,
+				import('astro/zod').ZodLiteral<'jpeg'>,
+				import('astro/zod').ZodLiteral<'tiff'>,
+				import('astro/zod').ZodLiteral<'webp'>,
+				import('astro/zod').ZodLiteral<'gif'>,
+				import('astro/zod').ZodLiteral<'svg'>
+			]
+		>;
+	}>;
 
 	type BaseSchemaWithoutEffects =
 		| import('astro/zod').AnyZodObject
@@ -16,63 +71,149 @@ declare module 'astro:content' {
 		| BaseSchemaWithoutEffects
 		| import('astro/zod').ZodEffects<BaseSchemaWithoutEffects>;
 
-	type BaseCollectionConfig<S extends BaseSchema> = {
-		schema?: S;
-		slug?: (entry: {
-			id: CollectionEntry<keyof typeof entryMap>['id'];
-			defaultSlug: string;
-			collection: string;
-			body: string;
-			data: import('astro/zod').infer<S>;
-		}) => string | Promise<string>;
-	};
-	export function defineCollection<S extends BaseSchema>(
-		input: BaseCollectionConfig<S>
-	): BaseCollectionConfig<S>;
+	export type SchemaContext = { image: ImageFunction };
 
-	type EntryMapKeys = keyof typeof entryMap;
+	type DataCollectionConfig<S extends BaseSchema> = {
+		type: 'data';
+		schema?: S | ((context: SchemaContext) => S);
+	};
+
+	type ContentCollectionConfig<S extends BaseSchema> = {
+		type?: 'content';
+		schema?: S | ((context: SchemaContext) => S);
+	};
+
+	type CollectionConfig<S> = ContentCollectionConfig<S> | DataCollectionConfig<S>;
+
+	export function defineCollection<S extends BaseSchema>(
+		input: CollectionConfig<S>
+	): CollectionConfig<S>;
+
 	type AllValuesOf<T> = T extends any ? T[keyof T] : never;
-	type ValidEntrySlug<C extends EntryMapKeys> = AllValuesOf<(typeof entryMap)[C]>['slug'];
+	type ValidContentEntrySlug<C extends keyof ContentEntryMap> = AllValuesOf<
+		ContentEntryMap[C]
+	>['slug'];
 
 	export function getEntryBySlug<
-		C extends keyof typeof entryMap,
-		E extends ValidEntrySlug<C> | (string & {})
+		C extends keyof ContentEntryMap,
+		E extends ValidContentEntrySlug<C> | (string & {})
 	>(
 		collection: C,
 		// Note that this has to accept a regular string too, for SSR
 		entrySlug: E
-	): E extends ValidEntrySlug<C>
+	): E extends ValidContentEntrySlug<C>
 		? Promise<CollectionEntry<C>>
 		: Promise<CollectionEntry<C> | undefined>;
-	export function getCollection<C extends keyof typeof entryMap>(
+
+	export function getDataEntryById<C extends keyof DataEntryMap, E extends keyof DataEntryMap[C]>(
 		collection: C,
-		filter?: (data: CollectionEntry<C>) => boolean
+		entryId: E
+	): Promise<CollectionEntry<C>>;
+
+	export function getCollection<C extends keyof AnyEntryMap, E extends CollectionEntry<C>>(
+		collection: C,
+		filter?: (entry: CollectionEntry<C>) => entry is E
+	): Promise<E[]>;
+	export function getCollection<C extends keyof AnyEntryMap>(
+		collection: C,
+		filter?: (entry: CollectionEntry<C>) => unknown
 	): Promise<CollectionEntry<C>[]>;
 
-	type InferEntrySchema<C extends keyof typeof entryMap> = import('astro/zod').infer<
-		Required<ContentConfig['collections'][C]>['schema']
+	export function getEntry<
+		C extends keyof ContentEntryMap,
+		E extends ValidContentEntrySlug<C> | (string & {})
+	>(entry: {
+		collection: C;
+		slug: E;
+	}): E extends ValidContentEntrySlug<C>
+		? Promise<CollectionEntry<C>>
+		: Promise<CollectionEntry<C> | undefined>;
+	export function getEntry<
+		C extends keyof DataEntryMap,
+		E extends keyof DataEntryMap[C] | (string & {})
+	>(entry: {
+		collection: C;
+		id: E;
+	}): E extends keyof DataEntryMap[C]
+		? Promise<DataEntryMap[C][E]>
+		: Promise<CollectionEntry<C> | undefined>;
+	export function getEntry<
+		C extends keyof ContentEntryMap,
+		E extends ValidContentEntrySlug<C> | (string & {})
+	>(
+		collection: C,
+		slug: E
+	): E extends ValidContentEntrySlug<C>
+		? Promise<CollectionEntry<C>>
+		: Promise<CollectionEntry<C> | undefined>;
+	export function getEntry<
+		C extends keyof DataEntryMap,
+		E extends keyof DataEntryMap[C] | (string & {})
+	>(
+		collection: C,
+		id: E
+	): E extends keyof DataEntryMap[C]
+		? Promise<DataEntryMap[C][E]>
+		: Promise<CollectionEntry<C> | undefined>;
+
+	/** Resolve an array of entry references from the same collection */
+	export function getEntries<C extends keyof ContentEntryMap>(
+		entries: {
+			collection: C;
+			slug: ValidContentEntrySlug<C>;
+		}[]
+	): Promise<CollectionEntry<C>[]>;
+	export function getEntries<C extends keyof DataEntryMap>(
+		entries: {
+			collection: C;
+			id: keyof DataEntryMap[C];
+		}[]
+	): Promise<CollectionEntry<C>[]>;
+
+	export function reference<C extends keyof AnyEntryMap>(
+		collection: C
+	): import('astro/zod').ZodEffects<
+		import('astro/zod').ZodString,
+		C extends keyof ContentEntryMap
+			? {
+					collection: C;
+					slug: ValidContentEntrySlug<C>;
+			  }
+			: {
+					collection: C;
+					id: keyof DataEntryMap[C];
+			  }
+	>;
+	// Allow generic `string` to avoid excessive type errors in the config
+	// if `dev` is not running to update as you edit.
+	// Invalid collection names will be caught at build time.
+	export function reference<C extends string>(
+		collection: C
+	): import('astro/zod').ZodEffects<import('astro/zod').ZodString, never>;
+
+	type ReturnTypeOrOriginal<T> = T extends (...args: any[]) => infer R ? R : T;
+	type InferEntrySchema<C extends keyof AnyEntryMap> = import('astro/zod').infer<
+		ReturnTypeOrOriginal<Required<ContentConfig['collections'][C]>['schema']>
 	>;
 
-	type Render = {
-		render(): Promise<{
-			Content: import('astro').MarkdownInstance<{}>['Content'];
-			headings: import('astro').MarkdownHeading[];
-			remarkPluginFrontmatter: Record<string, any>;
-		}>;
-	};
-
-	const entryMap: {
+	type ContentEntryMap = {
 		"blog": {
 "junteenth-recognition-concert.mdx": {
-  id: "junteenth-recognition-concert.mdx",
-  slug: "junteenth-recognition-concert",
-  body: string,
-  collection: "blog",
+	id: "junteenth-recognition-concert.mdx";
+  slug: "junteenth-recognition-concert";
+  body: string;
+  collection: "blog";
   data: InferEntrySchema<"blog">
-},
-},
+} & { render(): Render[".mdx"] };
+};
 
 	};
+
+	type DataEntryMap = {
+		
+	};
+
+	type AnyEntryMap = ContentEntryMap & DataEntryMap;
 
 	type ContentConfig = typeof import("../src/content/config");
 }

--- a/src/content/blog/junteenth-recognition-concert.mdx
+++ b/src/content/blog/junteenth-recognition-concert.mdx
@@ -1,8 +1,28 @@
 ---
 title: 'Juneteenth Recognition Concert'
+venue: 'Cathedral Basilica of St. Augustine'
+address: '38 Cathedral Place, St. Augustine, FL 32084'
+concertDay: 'Monday'
+concertDate: 'June 19, 2023'
+concertTime: '7:30 PM'
 description: 'The Ritz Chamber Players will perform a concert in recognition of Juneteenth. The concert will feature music by African American composers. Our special guest for the night will be Ann Marie McPhail, soprano.'
-pubDate: ''
-heroImage: ''
+artists:
+  - name: 'The Ritz Chamber Players'
+    instrument: ''
+    specialGuest: false
+    img: '/event-assets/ritz.jpg'
+  - name: 'Anne Marie McPhail'
+    instrument: 'Soprano'
+    specialGuest: true
+    img: '/event-assets/ann-marie-mcphail.png'
+program:
+  - composer: 'Samuel Colridge-Taylor'
+    title: 'Five Fantasiestücke, op. 5'
+  - composer: 'Coleridge-Taylor Perkinson'
+    title: 'String Quartet No. 1, "Calvary"'
+  - composer: 'Traditional Folk Songs'
+    title: 'performed by Anne Marie McPhail'
+cardImg: '/event-assets/juneteenth-placehold.png/'
 ---
 
 import { Icon } from 'astro-icon'

--- a/src/content/blog/junteenth-recognition-concert.mdx
+++ b/src/content/blog/junteenth-recognition-concert.mdx
@@ -23,18 +23,21 @@ program:
   - composer: 'Traditional Folk Songs'
     title: 'performed by Anne Marie McPhail'
 cardImg: '/event-assets/juneteenth-placehold.png/'
+cardMonth: 'June'
+cardDay: 19
+cardYear: 2023 
 ---
-
+export const { venue, address, concertDay, concertDate, concertTime, description, artists, program, cardImg, cardMonth, cardDay, cardYear } = frontmatter
 import { Icon } from 'astro-icon'
 
 <div class="flex flex-col-reverse items-center lg:flex-row justify-between">
     <div>
         <div class="flex flex-col gap-4 max-w-[665px] items-center lg:items-start text-center sm:text-left">
-            **Cathedral Basilica of St. Augustine**
+            **{venue}**
             
-            38 Cathedral Place, St. Augustine, FL 32084
+            {address}
 
-            Monday, **June 19**, 2023 @ 7:30 PM
+            {concertDay}, **{cardMonth} {cardDay}**, {cardYear} @ {concertTime}
             <div class="flex flex-col items-center sm:flex-row sm:gap-6">
                 <a
                 class="button has-icon color-secondary my-2 w-fit"
@@ -53,11 +56,11 @@ import { Icon } from 'astro-icon'
                 Program Notes
                 </a>
             </div>
-            <p class="text-center lg:text-left">The Ritz Chamber Players will perform a concert in recognition of Juneteenth. The concert will feature music by African American composers. Our special guest for the night will be Ann Marie McPhail, soprano.</p>
+            <p class="text-center lg:text-left">{description}</p>
         </div>
     </div>
     <div class="mb-6 lg:mb-0">
-        <img src="/event-assets/juneteenth-placehold.png" alt="Celebrate Juneteenth Freedom Day" class="w-[455px] h-[276px]" />
+        <img src={cardImg} alt="Celebrate Juneteenth Freedom Day" class="w-[455px] h-[276px]" />
     </div>
 
 </div>
@@ -67,21 +70,21 @@ import { Icon } from 'astro-icon'
         ### Featured Artists
         <div class="flex flex-col items-center sm:items-start sm:flex-row gap-10 my-4">
             <div>
-                <img src="/event-assets/ritz.jpg" alt="The Ritz Chamber Players" class="w-[300px] h-[300px]" />
-                **The Ritz Chamber Players**
+                <img src={artists[0].img} alt={artists[0].name} class="w-[300px] h-[300px]" />
+                **{artists[0].name}**
             </div>
             <div>
-                <img src="/event-assets/ann-marie-mcphail.png" alt="Ann Marie McPhail" class="w-[200px] h-[300px] pl-7 lg:pl-0" />
-                **Anne Marie McPhail, *Soprano***
+                <img src={artists[1].img} alt={artists[1].name} class="w-[200px] h-[300px] pl-7 lg:pl-0" />
+                **{artists[1].name}, *{artists[1].instrument}***
             </div>
         </div>
     </div>
     <div class="flex flex-col sm:text-center lg:text-left pt-6 lg:pt-0">
         <h3 class="text-center xl:text-left">Program</h3>
         <div class="flex flex-col gap-6 my-4 text-center post-custom:text-left">
-            <p class="flex flex-col custom:flex-col post-custom:flex-row gap-2"><span><strong>Samuel Colridge-Taylor:</strong></span><span> Five Fantasiestücke, Op. 5</span></p>
-            <p class="flex flex-col custom:flex-col post-custom:flex-row gap-2"><span><strong>Coleridge-Taylor Perkinson:</strong></span><span> String Quartet No. 1, "Calvary"</span></p>
-            <p class="flex flex-col custom:flex-col post-custom:flex-row gap-2"><span><strong>Traditional Folk Songs:</strong></span><span> performed by Anne Marie McPhail</span></p>
+            <p class="flex flex-col custom:flex-col post-custom:flex-row gap-2"><span><strong>{program[0].composer}</strong></span><span> {program[0].title}</span></p>
+            <p class="flex flex-col custom:flex-col post-custom:flex-row gap-2"><span><strong>{program[1].composer}</strong></span><span> {program[1].title}</span></p>
+            <p class="flex flex-col custom:flex-col post-custom:flex-row gap-2"><span><strong>{program[2].composer}</strong></span><span> {program[2].title}</span></p>
         </div>
     </div>
 

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -4,18 +4,25 @@ const blog = defineCollection({
   // Type-check frontmatter using a schema
   schema: z.object({
     title: z.string(),
+    venue: z.string(),
+    address: z.string(),
+    concertDay: z.string(),
+    concertDate: z.string(),
+    concertTime: z.string(),
     description: z.string(),
-    // Transform string to Date object
-    pubDate: z
-      .string()
-      .or(z.date())
-      .transform((val) => new Date(val)),
-    updatedDate: z
-      .string()
-      .optional()
-      .transform((str) => (str ? new Date(str) : undefined)),
-    heroImage: z.string().optional(),
+    artists: z.array(z.object({
+      name: z.string(),
+      instrument: z.string().optional(),
+      specialGuest: z.boolean(),
+      img: z.string(),
+    })),
+    program: z.array(z.object({
+      composer: z.string(),
+      title: z.string(),
+    })),
+    cardImg: z.string(),
   }),
 })
 
 export const collections = { blog }
+

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -21,6 +21,9 @@ const blog = defineCollection({
       title: z.string(),
     })),
     cardImg: z.string(),
+    cardMonth: z.string(),
+    cardDay: z.number(),
+    cardYear: z.number(),
   }),
 })
 

--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -40,5 +40,3 @@ const posts = (await getCollection('blog')).sort((a, b) => a.data.pubDate.valueO
     </ul>
   </section>
 </DefaultLayout>
-
-<!-- 640  729-->

--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -14,7 +14,7 @@ const posts = (await getCollection('blog')).sort((a, b) => a.data.pubDate.valueO
           <div class="relative mb-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
             <Card
               url={`/events/${post.slug}/`}
-              img="/event-assets/juneteenth-placehold.png/"
+              img={post.data.cardImg}
               title=""
               children=""
               footer=""
@@ -22,15 +22,25 @@ const posts = (await getCollection('blog')).sort((a, b) => a.data.pubDate.valueO
               <h3 class="mb-2">{post.data.title}</h3>
               <div class="flex flex-col">
                 <div class="mt-3 flex flex-col gap-[6px]">
-                  <p class="font-semibold">The Ritz Chamber Players</p>
-                  <p class="text-xs italic">with special guest</p>
-                  <p class="font-semibold">
-                    Anne Marie McPhail, <i>Soprano</i>
-                  </p>
+                  {
+                    post.data.artists.filter(artist => !artist.specialGuest).map((artist) => (
+                      <p class="font-semibold" id="map-regular-artists">{artist.name}</p>
+                    ))
+                  }
+                  {post.data.artists.some(artist => artist.specialGuest) && (
+                    <p class="text-xs italic" id="render-when-special-artists-exist">with special guest</p>
+                  )}
+                  {
+                    post.data.artists.filter(artist => artist.specialGuest).map((artist) => (
+                      <p class="font-semibold" id="map-special-artists">
+                        {artist.name}, <i>{artist.instrument}</i>
+                      </p>
+                    ))
+                  }
                 </div>
                 <div class="absolute flex flex-col items-center bottom-0 cal:bottom-[2rem] right-0 border-l-2 border-t-2 sm:border-2 border-neutral-900 px-2 sm:m-4 cal:m-1 lg:m-2 cal:px-[0.75rem] sm:px-[0.65rem] sm:py-1 lg:px-3">
-                  <p>June</p>
-                  <p class="text-3xl font-bold">19</p>
+                  <p>{post.data.cardMonth}</p>
+                  <p class="text-3xl font-bold">{post.data.cardDay}</p>
                 </div>
               </div>
             </Card>


### PR DESCRIPTION
# What got done

- YAML in posts now align with `defineCollection` schema in `/content/blog/config.ts`
- MDX event posts are reading YAML vars and `Card` component is reading YAML vars within its own slug

Nothing is really hardcoded now except for tailwind classes in case we need to do stylistic things to individual events. Essentially copy pastable now. LOL

